### PR TITLE
Update to latest runner version and install iputils-ping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:buster-slim
 
-ARG GITHUB_RUNNER_VERSION="2.263.0"
+ARG GITHUB_RUNNER_VERSION="2.267.1"
 
 ENV RUNNER_NAME "runner"
 ENV GITHUB_PAT ""
@@ -15,6 +15,7 @@ RUN apt-get update \
         sudo \
         git \
         jq \
+        iputils-ping \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -m github \


### PR DESCRIPTION
Hi @SanderKnape.

The current version of the self-hosted runner is not working anymore.
After one successful job the runner tries to run an auto-update:

```
-------------------------------------------------------------------------------- 
|        ____ _ _   _   _       _          _        _   _                      | 
|       / ___(_) |_| | | |_   _| |__      / \   ___| |_(_) ___  _ __  ___      | 
|      | |  _| | __| |_| | | | | '_ \    / _ \ / __| __| |/ _ \| '_ \/ __|     | 
|      | |_| | | |_|  _  | |_| | |_) |  / ___ \ (__| |_| | (_) | | | \__ \     | 
|       \____|_|\__|_| |_|\__,_|_.__/  /_/   \_\___|\__|_|\___/|_| |_|___/     | 
|                                                                              | 
|                       Self-hosted runner registration                        | 
|                                                                              | 
-------------------------------------------------------------------------------- 
 
# Authentication 
 
 
√ Connected to GitHub 
 
# Runner Registration 
 
 
 
√ Runner successfully added 
√ Runner connection is good 
 
# Runner settings 
 
 
√ Settings Saved. 
 
 
√ Connected to GitHub 
 
2020-08-04 06:58:07Z: Listening for Jobs 
Runner update in progress, do not shutdown runner. 
Downloading 2.267.1 runner 
Waiting for current job finish running. 
Generate and execute update script. 
Runner will exit shortly for update, should back online within 10 seconds. 
/home/github/_work/_update.sh: line 31: ping: command not found 
/home/github/_work/_update.sh: line 31: ping: command not found 
/home/github/_work/_update.sh: line 31: ping: command not found 
/home/github/_work/_update.sh: line 31: ping: command not found 
/home/github/_work/_update.sh: line 31: ping: command not found 
/home/github/_work/_update.sh: line 31: ping: command not found 
...
```