### PR TITLE
Request a new token when remove a self-hosted runner

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,10 @@ export RUNNER_TOKEN=$(echo $payload | jq .token --raw-output)
     --replace
 
 remove() {
-    ./config.sh remove --unattended --token "${RUNNER_TOKEN}"
+    payload=$(curl -sX POST -H "Authorization: token ${GITHUB_PAT}" ${token_url%/registration-token}/remove-token)
+    export REMOVE_TOKEN=$(echo $payload | jq .token --raw-output)
+
+    ./config.sh remove --unattended --token "${REMOVE_TOKEN}"
 }
 
 trap 'remove; exit 130' INT


### PR DESCRIPTION
Hi @SanderKnape.

Unfortunately, it is currently not always possible to remove a self-hosted runner cleanly,
because the `RUNNER_TOKEN` expires after one hour. For more information please visit:

- [Create a remove token for an organization](https://docs.github.com/en/rest/reference/actions#create-a-remove-token-for-an-organization)
- [Create a remove token for a repository](https://docs.github.com/en/rest/reference/actions#create-a-remove-token-for-a-repository)

```
--------------------------------------------------------------------------------
|        ____ _ _   _   _       _          _        _   _                      |
|       / ___(_) |_| | | |_   _| |__      / \   ___| |_(_) ___  _ __  ___      |
|      | |  _| | __| |_| | | | | '_ \    / _ \ / __| __| |/ _ \| '_ \/ __|     |
|      | |_| | | |_|  _  | |_| | |_) |  / ___ \ (__| |_| | (_) | | | \__ \     |
|       \____|_|\__|_| |_|\__,_|_.__/  /_/   \_\___|\__|_|\___/|_| |_|___/     |
|                                                                              |
|                       Self-hosted runner registration                        |
|                                                                              |
--------------------------------------------------------------------------------

# Authentication


√ Connected to GitHub

# Runner Registration



√ Runner successfully added
√ Runner connection is good

# Runner settings


√ Settings Saved.


√ Connected to GitHub

2020-08-10 07:23:14Z: Listening for Jobs
2020-08-10 09:06:12Z: Runner connect error: The HTTP request timed out after 00:01:00.. Retrying until reconnected.
2020-08-10 09:07:29Z: Runner reconnected.

# Runner removal

Http response code: Unauthorized from 'POST https://api.github.com/actions/runner-registration'
{"message":"Token expired.","documentation_url":"https://docs.github.com/rest"}
Failed: Removing runner from the server
Response status code does not indicate success: 401 (Unauthorized).
```