### PR TITLE
entrypoint: use RUNNER_NAME instead of hostname

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM debian:buster-slim
 
-ENV RUNNER_NAME "runner"
 ENV GITHUB_PAT ""
 ENV GITHUB_OWNER ""
 ENV GITHUB_REPOSITORY ""

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,8 +12,12 @@ echo "Requesting token at '${token_url}'"
 payload=$(curl -sX POST -H "Authorization: token ${GITHUB_PAT}" ${token_url})
 export RUNNER_TOKEN=$(echo $payload | jq .token --raw-output)
 
+if [ -z "${RUNNER_NAME}" ]; then
+    RUNNER_NAME=$(hostname)
+fi
+
 ./config.sh \
-    --name $(hostname) \
+    --name ${RUNNER_NAME} \
     --token ${RUNNER_TOKEN} \
     --url ${registration_url} \
     --work ${RUNNER_WORKDIR} \


### PR DESCRIPTION
This will configure the runner to use the `RUNNER_NAME` environmental variable if it is set; otherwise, it will default to the `$(hostname)` as it is currently configured.