### PR TITLE
Build on Arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,11 @@ ENV RUNNER_LABELS ""
 ENV DOCKER_BUCKET get.docker.com
 ENV DOCKER_VERSION 19.03.6
 
+ENV DOTNET_SDK_VERSION=5.0
+
 RUN apt-get update \
     && apt-get install -y \
+	apt-utils \
         curl \
         sudo \
         git \
@@ -24,14 +27,20 @@ RUN apt-get update \
 	pkg-config \
 	openssl \
 	libssl-dev \
+	zip \
+	libc6 \
+	libgcc1 \
+	libicu63 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -m github \
     && usermod -aG sudo github \
     && echo "%sudo ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
+# Upgrade NPM
 RUN npm install npm@latest -g
 
+# Install Docker
 RUN ARCH=$(lscpu | grep Architecture | tr -d ' ' | cut -d : -f 2) \
         && set -x \
         && curl -fSL "https://download.docker.com/linux/static/stable/${ARCH}/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
@@ -41,8 +50,18 @@ RUN ARCH=$(lscpu | grep Architecture | tr -d ' ' | cut -d : -f 2) \
         && rm docker.tgz \
         && docker -v
 
+# Install .NET 5
+RUN wget https://dot.net/v1/dotnet-install.sh \
+	&& chmod u+x dotnet-install.sh
+RUN ./dotnet-install.sh -c ${DOTNET_SDK_VERSION} -InstallDir /usr/share/dotnet/ \
+	&& ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
+	
+# Install github runner
 USER github
 WORKDIR /home/github
+
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain=nightly && echo 'source $HOME/.cargo/env' >> $HOME/.bashr
+ENV PATH="$HOME/.cargo/bin:${PATH}"
 
 RUN ARCH=$(lscpu | grep Architecture | tr -d ' ' | cut -d : -f 2) \
         && if [ $ARCH != "aarch64" ]; then ARCH=x64; else ARCH=arm64; fi \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ ENV GITHUB_REPOSITORY ""
 ENV RUNNER_WORKDIR "_work"
 ENV RUNNER_LABELS ""
 
+ENV DOCKER_BUCKET get.docker.com
+ENV DOCKER_VERSION 19.03.6
+
 RUN apt-get update \
     && apt-get install -y \
         curl \
@@ -13,18 +16,29 @@ RUN apt-get update \
         git \
         jq \
         iputils-ping \
+        unzip \
+        wget \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -m github \
     && usermod -aG sudo github \
     && echo "%sudo ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
+RUN ARCH=$(lscpu | grep Architecture | tr -d ' ' | cut -d : -f 2) \
+        && set -x \
+        && curl -fSL "https://download.docker.com/linux/static/stable/${ARCH}/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
+        && tar -xzvf docker.tgz \
+        && mv docker/* /usr/local/bin/ \
+        && rmdir docker \
+        && rm docker.tgz \
+        && docker -v
+
 USER github
 WORKDIR /home/github
 
 RUN ARCH=$(lscpu | grep Architecture | tr -d ' ' | cut -d : -f 2) \
-    && if [ $ARCH != "aarch64" ]; then ARCH=x64; else ARCH=arm64; fi \
-    && GITHUB_RUNNER_VERSION=$(curl --silent "https://api.github.com/repos/actions/runner/releases/latest" | jq -r '.tag_name[1:]') \
+        && if [ $ARCH != "aarch64" ]; then ARCH=x64; else ARCH=arm64; fi \
+        && GITHUB_RUNNER_VERSION=$(curl --silent "https://api.github.com/repos/actions/runner/releases/latest" | jq -r '.tag_name[1:]') \
     && curl -Ls https://github.com/actions/runner/releases/download/v${GITHUB_RUNNER_VERSION}/actions-runner-linux-${ARCH}-${GITHUB_RUNNER_VERSION}.tar.gz | tar xz \
     && sudo ./bin/installdependencies.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,19 @@ RUN apt-get update \
         iputils-ping \
         unzip \
         wget \
+	nodejs \
+	npm \
+	apt-utils \
+	pkg-config \
+	openssl \
+	libssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -m github \
     && usermod -aG sudo github \
     && echo "%sudo ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+RUN npm install npm@latest -g
 
 RUN ARCH=$(lscpu | grep Architecture | tr -d ' ' | cut -d : -f 2) \
         && set -x \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,10 @@ RUN apt-get update \
 USER github
 WORKDIR /home/github
 
-RUN GITHUB_RUNNER_VERSION=$(curl --silent "https://api.github.com/repos/actions/runner/releases/latest" | jq -r '.tag_name[1:]') \
-    && curl -Ls https://github.com/actions/runner/releases/download/v${GITHUB_RUNNER_VERSION}/actions-runner-linux-x64-${GITHUB_RUNNER_VERSION}.tar.gz | tar xz \
+RUN ARCH=$(lscpu | grep Architecture | tr -d ' ' | cut -d : -f 2) \
+    && if [ $ARCH != "aarch64" ]; then ARCH=x64; else ARCH=arm64; fi \
+    && GITHUB_RUNNER_VERSION=$(curl --silent "https://api.github.com/repos/actions/runner/releases/latest" | jq -r '.tag_name[1:]') \
+    && curl -Ls https://github.com/actions/runner/releases/download/v${GITHUB_RUNNER_VERSION}/actions-runner-linux-${ARCH}-${GITHUB_RUNNER_VERSION}.tar.gz | tar xz \
     && sudo ./bin/installdependencies.sh
 
 COPY --chown=github:github entrypoint.sh runsvc.sh ./

--- a/config
+++ b/config
@@ -1,0 +1,6 @@
+[build]
+rustc-wrapper = "/home/github/.cargo/bin/sccache"
+
+rustflags = [
+  "-C", "link-arg=-fuse-ld=lld",
+]


### PR DESCRIPTION
Hi @SanderKnape,

thx for providing this container. I tried to get in working on a Raspberry Pi 4 with an arm64 CPU but if failed due to the download of the x64 runner.

I changed the Dockerfile such that there is a simple test if the current machine is an x64 or an arm64 and downloads the corresponding binaries.

I'm now able to run the github-runner on a k8s cluster on a Raspberry Pi. As I do not want to maintain a separate port, here is PR.

Btw.: If the container starts without the GITHUB_REPOSITIORY set, as documented if you want it for the whole organization, it does not work. But as that's a different issue I guess.

regards,
 secana